### PR TITLE
updated syntax

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         target: [x86_64, aarch64]

--- a/examples/basics.ipynb
+++ b/examples/basics.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "import polars as pl\n",
-    "import polars_istr  # noqa: F401"
+    "import polars_istr as istr"
    ]
   },
   {
@@ -35,7 +35,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>iban</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;AA110011123Z56…</td></tr><tr><td>&quot;DE445001051754…</td></tr><tr><td>&quot;AD120001203020…</td></tr><tr><td>&quot;MR000002000101…</td></tr></tbody></table></div>"
+       "<small>shape: (4, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>iban</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;AA110011123Z5678&quot;</td></tr><tr><td>&quot;DE44500105175407324931&quot;</td></tr><tr><td>&quot;AD1200012030200359100100&quot;</td></tr><tr><td>&quot;MR0000020001010000123456754&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 1)\n",
@@ -81,7 +81,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>country_code</th><th>reason</th><th>is_valid</th><th>bban</th><th>bank_id</th><th>branch_id</th></tr><tr><td>str</td><td>str</td><td>bool</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>null</td><td>&quot;Invalid countr…</td><td>false</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;DE&quot;</td><td>&quot;ok&quot;</td><td>true</td><td>&quot;50010517540732…</td><td>&quot;50010517&quot;</td><td>null</td></tr><tr><td>&quot;AD&quot;</td><td>&quot;ok&quot;</td><td>true</td><td>&quot;00012030200359…</td><td>&quot;0001&quot;</td><td>&quot;2030&quot;</td></tr><tr><td>null</td><td>&quot;Invalid checks…</td><td>false</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (4, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>country_code</th><th>reason</th><th>is_valid</th><th>bban</th><th>bank_id</th><th>branch_id</th></tr><tr><td>str</td><td>str</td><td>bool</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>null</td><td>&quot;Invalid country code&quot;</td><td>false</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;DE&quot;</td><td>&quot;ok&quot;</td><td>true</td><td>&quot;500105175407324931&quot;</td><td>&quot;50010517&quot;</td><td>null</td></tr><tr><td>&quot;AD&quot;</td><td>&quot;ok&quot;</td><td>true</td><td>&quot;00012030200359100100&quot;</td><td>&quot;0001&quot;</td><td>&quot;2030&quot;</td></tr><tr><td>null</td><td>&quot;Invalid checksum&quot;</td><td>false</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 6)\n",
@@ -104,12 +104,12 @@
    ],
    "source": [
     "df.select(\n",
-    "    pl.col(\"iban\").iban.country_code().alias(\"country_code\"),\n",
-    "    pl.col(\"iban\").iban.check().alias(\"reason\"),\n",
-    "    pl.col(\"iban\").iban.is_valid().alias(\"is_valid\"),\n",
-    "    pl.col(\"iban\").iban.bban().alias(\"bban\"),\n",
-    "    pl.col(\"iban\").iban.bank_id().alias(\"bank_id\"),\n",
-    "    pl.col(\"iban\").iban.branch_id().alias(\"branch_id\"),\n",
+    "    istr.iban_country_code(\"iban\").alias(\"country_code\"),\n",
+    "    istr.iban_check(\"iban\").alias(\"reason\"),\n",
+    "    istr.iban_is_valid(\"iban\").alias(\"is_valid\"),\n",
+    "    istr.iban_bban(\"iban\").alias(\"bban\"),\n",
+    "    istr.iban_bank_id(\"iban\").alias(\"bank_id\"),\n",
+    "    istr.iban_branch_id(\"iban\").alias(\"branch_id\"),\n",
     ") "
    ]
   },
@@ -129,7 +129,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (4, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>country_code</th><th>check_digits</th><th>bban</th><th>bank_id</th><th>branch_id</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;DE&quot;</td><td>&quot;44&quot;</td><td>&quot;50010517540732…</td><td>&quot;50010517&quot;</td><td>null</td></tr><tr><td>&quot;AD&quot;</td><td>&quot;12&quot;</td><td>&quot;00012030200359…</td><td>&quot;0001&quot;</td><td>&quot;2030&quot;</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (4, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>country_code</th><th>check_digits</th><th>bban</th><th>bank_id</th><th>branch_id</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;DE&quot;</td><td>&quot;44&quot;</td><td>&quot;500105175407324931&quot;</td><td>&quot;50010517&quot;</td><td>null</td></tr><tr><td>&quot;AD&quot;</td><td>&quot;12&quot;</td><td>&quot;00012030200359100100&quot;</td><td>&quot;0001&quot;</td><td>&quot;2030&quot;</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (4, 5)\n",
@@ -152,7 +152,7 @@
    ],
    "source": [
     "df.select(\n",
-    "    pl.col(\"iban\").iban.extract_all().alias(\"ib\")\n",
+    "    istr.iban_extract_all(\"iban\").alias(\"ib\")\n",
     ").unnest(\"ib\")"
    ]
   },
@@ -259,10 +259,10 @@
    ],
    "source": [
     "df.select(\n",
-    "    pl.col(\"isin\").isin.country_code().alias(\"country_code\"),\n",
-    "    pl.col(\"isin\").isin.check_digit().alias(\"check_digit\"),\n",
-    "    pl.col(\"isin\").isin.security_id().alias(\"security_id\"),\n",
-    "    pl.col(\"isin\").isin.is_valid().alias(\"is_valid\"),\n",
+    "    istr.isin_country_code(\"isin\").alias(\"country_code\"),\n",
+    "    istr.isin_check_digit(\"isin\").alias(\"check_digit\"),\n",
+    "    istr.isin_security_id(\"isin\").alias(\"security_id\"),\n",
+    "    istr.isin_is_valid(\"isin\").alias(\"is_valid\"),\n",
     ")"
    ]
   },
@@ -314,7 +314,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (9, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>host</th><th>domain</th><th>fragment</th><th>path</th><th>query</th><th>check</th><th>is_valid</th><th>is_special</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>bool</td><td>bool</td></tr></thead><tbody><tr><td>&quot;example.com&quot;</td><td>&quot;example.com&quot;</td><td>&quot;row=4&quot;</td><td>&quot;/data.csv&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL w…</td><td>false</td><td>null</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL w…</td><td>false</td><td>null</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL w…</td><td>false</td><td>null</td></tr><tr><td>&quot;127.0.0.1&quot;</td><td>null</td><td>null</td><td>&quot;/&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>&quot;test.com&quot;</td><td>&quot;test.com&quot;</td><td>null</td><td>&quot;/&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>&quot;/tmp/foo&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>&quot;example.com&quot;</td><td>&quot;example.com&quot;</td><td>null</td><td>&quot;/products&quot;</td><td>&quot;page=2&amp;sort=de…</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (9, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>host</th><th>domain</th><th>fragment</th><th>path</th><th>query</th><th>check</th><th>is_valid</th><th>is_special</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>bool</td><td>bool</td></tr></thead><tbody><tr><td>&quot;example.com&quot;</td><td>&quot;example.com&quot;</td><td>&quot;row=4&quot;</td><td>&quot;/data.csv&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL without a base&quot;</td><td>false</td><td>null</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL without a base&quot;</td><td>false</td><td>null</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&quot;relative URL without a base&quot;</td><td>false</td><td>null</td></tr><tr><td>&quot;127.0.0.1&quot;</td><td>null</td><td>null</td><td>&quot;/&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>&quot;test.com&quot;</td><td>&quot;test.com&quot;</td><td>null</td><td>&quot;/&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>&quot;/tmp/foo&quot;</td><td>null</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>&quot;example.com&quot;</td><td>&quot;example.com&quot;</td><td>null</td><td>&quot;/products&quot;</td><td>&quot;page=2&amp;sort=desc&quot;</td><td>&quot;ok&quot;</td><td>true</td><td>true</td></tr><tr><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (9, 8)\n",
@@ -353,14 +353,14 @@
    ],
    "source": [
     "df.select(\n",
-    "    pl.col(\"url\").url.host().alias(\"host\"),\n",
-    "    pl.col(\"url\").url.domain().alias(\"domain\"),\n",
-    "    pl.col(\"url\").url.fragment().alias(\"fragment\"),\n",
-    "    pl.col(\"url\").url.path().alias(\"path\"),\n",
-    "    pl.col(\"url\").url.query().alias(\"query\"),\n",
-    "    pl.col(\"url\").url.check().alias(\"check\"),\n",
-    "    pl.col(\"url\").url.is_valid().alias(\"is_valid\"),\n",
-    "    pl.col(\"url\").url.is_special().alias(\"is_special\"),\n",
+    "    istr.url_host(\"url\").alias(\"host\"),\n",
+    "    istr.url_domain(\"url\").alias(\"domain\"),\n",
+    "    istr.url_fragment(\"url\").alias(\"fragment\"),\n",
+    "    istr.url_path(\"url\").alias(\"path\"),\n",
+    "    istr.url_query(\"url\").alias(\"query\"),\n",
+    "    istr.url_check(\"url\").alias(\"check\"),\n",
+    "    istr.url_is_valid(\"url\").alias(\"is_valid\"),\n",
+    "    istr.url_is_special(\"url\").alias(\"is_special\"),\n",
     ")"
    ]
   },
@@ -429,17 +429,17 @@
    ],
    "source": [
     "df.select(\n",
-    "        pl.col(\"cusip\").cusip.issue_num().alias(\"issue_num\"),\n",
-    "        pl.col(\"cusip\").cusip.issuer_num().alias(\"issuer_num\"),\n",
-    "        pl.col(\"cusip\").cusip.check_digit().alias(\"check_digit\"),\n",
-    "        pl.col(\"cusip\").cusip.country_code().alias(\"country_code\"),\n",
-    "        pl.col(\"cusip\").cusip.payload().alias(\"payload\"),\n",
-    "        pl.col(\"cusip\").cusip.is_private_issue().alias(\"is_private_issue\"),\n",
-    "        pl.col(\"cusip\").cusip.has_private_issuer().alias(\"has_private_issuer\"),\n",
-    "        pl.col(\"cusip\").cusip.is_private_use().alias(\"is_private_use\"),\n",
-    "        pl.col(\"cusip\").cusip.is_cins().alias(\"is_cins\"),\n",
-    "        pl.col(\"cusip\").cusip.is_cins_base().alias(\"is_cins_base\"),\n",
-    "        pl.col(\"cusip\").cusip.is_cins_extended().alias(\"is_cins_extended\"),\n",
+    "        istr.cusip_issue_num(\"cusip\").alias(\"issue_num\"),\n",
+    "        istr.cusip_issuer_num(\"cusip\").alias(\"issuer_num\"),\n",
+    "        istr.cusip_check_digit(\"cusip\").alias(\"check_digit\"),\n",
+    "        istr.cusip_country_code(\"cusip\").alias(\"country_code\"),\n",
+    "        istr.cusip_payload(\"cusip\").alias(\"payload\"),\n",
+    "        istr.cusip_is_private_issue(\"cusip\").alias(\"is_private_issue\"),\n",
+    "        istr.cusip_has_private_issuer(\"cusip\").alias(\"has_private_issuer\"),\n",
+    "        istr.cusip_is_private_use(\"cusip\").alias(\"is_private_use\"),\n",
+    "        istr.cusip_is_cins(\"cusip\").alias(\"is_cins\"),\n",
+    "        istr.cusip_is_cins_base(\"cusip\").alias(\"is_cins_base\"),\n",
+    "        istr.cusip_is_cins_extended(\"cusip\").alias(\"is_cins_extended\"),\n",
     "    )"
    ]
   },
@@ -476,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/python/polars_istr/__init__.py
+++ b/python/polars_istr/__init__.py
@@ -1,7 +1,6 @@
-from .iban import IbanExt  # noqa: E402
-from .isin import IsinExt  # noqa: E402
-from .cusip import CusipExt  # noqa: E402
-from .url import UrlExt  # noqa: E402
+from .iban import *  # noqa: E402, F403
+from .isin import *  # noqa: E402, F403
+from .cusip import *  # noqa: E402, F403
+from .url import *  # noqa: E402, F403
 
 __version__ = "0.1.0"
-__all__ = ["IbanExt", "IsinExt", "CusipExt", "UrlExt"]

--- a/python/polars_istr/_utils.py
+++ b/python/polars_istr/_utils.py
@@ -1,0 +1,52 @@
+import polars as pl
+from typing import Any, Optional, List, Dict
+from .type_alias import StrOrExpr
+
+
+def str_to_expr(x: StrOrExpr) -> pl.Expr:
+    if isinstance(x, str):
+        return pl.col(x)
+    elif isinstance(x, pl.Expr):
+        return x
+    else:
+        raise ValueError("Can only parse str (column name) or Polars expressions.")
+
+
+def pl_plugin(
+    *,
+    lib: str,
+    symbol: str,
+    args: List[StrOrExpr],
+    kwargs: Optional[Dict[str, Any]] = None,
+    is_elementwise: bool = False,
+    returns_scalar: bool = False,
+    changes_length: bool = False,
+    cast_to_supertype: bool = False,
+) -> pl.Expr:
+    # pl.__version__ should always be a valid version number, so split returns always 3 strs
+    if tuple(int(x) for x in pl.__version__.split(".")) < (0, 20, 16):
+        # This will eventually be deprecated?
+        first = str_to_expr(args[0])
+        return first.register_plugin(
+            lib=lib,
+            symbol=symbol,
+            args=[str_to_expr(x) for x in args[1:]],
+            kwargs=kwargs,
+            is_elementwise=is_elementwise,
+            returns_scalar=returns_scalar,
+            changes_length=changes_length,
+            cast_to_supertype=cast_to_supertype,
+        )
+
+    from polars.plugins import register_plugin_function
+
+    return register_plugin_function(
+        plugin_path=lib,
+        args=[str_to_expr(x) for x in args],
+        function_name=symbol,
+        kwargs=kwargs,
+        is_elementwise=is_elementwise,
+        returns_scalar=returns_scalar,
+        changes_length=changes_length,
+        cast_to_supertype=cast_to_supertype,
+    )

--- a/python/polars_istr/cusip.py
+++ b/python/polars_istr/cusip.py
@@ -1,8 +1,153 @@
 from __future__ import annotations
 import polars as pl
 from polars.utils.udfs import _get_shared_lib_location
+from ._utils import pl_plugin, StrOrExpr
 
 _lib = _get_shared_lib_location(__file__)
+
+
+def cusip_extract_all(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a struct containing country_code, issue_num, issuer_num, check_digit,
+    or null, if it cannot be parsed.
+
+    Country Code is null for valid CUSIPs which are not (extended) CINS
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_full",
+        is_elementwise=True,
+    )
+
+
+def cusip_issue_num(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the issue number from the CUSIP, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_issue_num",
+        is_elementwise=True,
+    )
+
+
+def cusip_issuer_num(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the issuer number from the CUSIP, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_issuer_num",
+        is_elementwise=True,
+    )
+
+
+def cusip_check_digit(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns check digit from the CUSIP, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_check_digit",
+        is_elementwise=True,
+    )
+
+
+def cusip_country_code(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the country code from the CUSIP, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_country_code",
+        is_elementwise=True,
+    )
+
+
+def cusip_payload(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the payload (CUSIP ex. check digit) from the CUSIP, or null if it
+    cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_payload",
+        is_elementwise=True,
+    )
+
+
+def cusip_is_private_issue(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns true if the issue number is reserved for private use.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_is_private_issue",
+        is_elementwise=True,
+    )
+
+
+def cusip_has_private_issuer(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns true if the issuer is reserved for private use.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_cusip_has_private_issuer",
+        is_elementwise=True,
+    )
+
+
+def cusip_is_private_use(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns True if either the issuer or issue number is reserved for
+    private use.
+    """
+    return pl_plugin(args=[x], lib=_lib, symbol="pl_cusip_is_private_use", is_elementwise=True)
+
+
+def cusip_is_cins(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns true if this CUSIP number is actually a
+    CUSIP International Numbering System (CINS) number,
+    false otherwise (i.e., that it has a letter as the first character of its issuer number).
+    See also is_cins_base() and is_cins_extended().
+
+    Null if unable to parse.
+    """
+    return pl_plugin(args=[x], lib=_lib, symbol="pl_cusip_is_cins", is_elementwise=True)
+
+
+def cusip_is_cins_base(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns true if this CUSIP identifier is actually a CUSIP International
+    Numbering System (CINS) identifier (with the further restriction that
+    it does not use `I`, `O` or `Z` as its country code), false otherwise.
+    See also is_cins() and is_cins_extended().
+
+    Null if unable to parse.
+    """
+    return pl_plugin(args=[x], lib=_lib, symbol="pl_cusip_is_cins_base", is_elementwise=True)
+
+
+def cusip_is_cins_extended(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns true if this CUSIP identifier is actually a CUSIP International
+    Numbering System (CINS) identifier (with the further restriction that
+    it does not use `I`, `O` or `Z` as its country code), false otherwise.
+    See also is_cins() and is_cins_extended().
+
+    Null if unable to parse.
+    """
+    return pl_plugin(args=[x], lib=_lib, symbol="pl_cusip_is_cins_extended", is_elementwise=True)
 
 
 @pl.api.register_expr_namespace("cusip")
@@ -19,12 +164,6 @@ class CusipExt:
         self._expr: pl.Expr = expr
 
     def extract_all(self) -> pl.Expr:
-        """
-        Returns a struct containing country_code, issue_num, issuer_num, check_digit,
-        or null, if it cannot be parsed.
-
-        Country Code is null for valid CUSIPs which are not (extended) CINS
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_full",
@@ -32,9 +171,6 @@ class CusipExt:
         )
 
     def issue_num(self) -> pl.Expr:
-        """
-        Returns the issue number from the CUSIP, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_issue_num",
@@ -42,9 +178,6 @@ class CusipExt:
         )
 
     def issuer_num(self) -> pl.Expr:
-        """
-        Returns the issuer number from the CUSIP, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_issuer_num",
@@ -52,9 +185,6 @@ class CusipExt:
         )
 
     def check_digit(self) -> pl.Expr:
-        """
-        Returns check digit from the CUSIP, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_check_digit",
@@ -62,9 +192,6 @@ class CusipExt:
         )
 
     def country_code(self) -> pl.Expr:
-        """
-        Returns the country code from the CUSIP, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_country_code",
@@ -72,10 +199,6 @@ class CusipExt:
         )
 
     def payload(self) -> pl.Expr:
-        """
-        Returns the payload (CUSIP ex. check digit) from the CUSIP, or null if it
-        cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_payload",
@@ -83,9 +206,6 @@ class CusipExt:
         )
 
     def is_private_issue(self) -> pl.Expr:
-        """
-        Returns true if the issue number is reserved for private use.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_is_private_issue",
@@ -93,9 +213,6 @@ class CusipExt:
         )
 
     def has_private_issuer(self) -> pl.Expr:
-        """
-        Returns true if the issuer is reserved for private use.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_cusip_has_private_issuer",
@@ -103,47 +220,19 @@ class CusipExt:
         )
 
     def is_private_use(self) -> pl.Expr:
-        """
-        Returns True if either the issuer or issue number is reserved for
-        private use.
-        """
         return self._expr.register_plugin(
             lib=_lib, symbol="pl_cusip_is_private_use", is_elementwise=True
         )
 
     def is_cins(self) -> pl.Expr:
-        """
-        Returns true if this CUSIP number is actually a
-        CUSIP International Numbering System (CINS) number,
-        false otherwise (i.e., that it has a letter as the first character of its issuer number).
-        See also is_cins_base() and is_cins_extended().
-
-        Null if unable to parse.
-        """
         return self._expr.register_plugin(lib=_lib, symbol="pl_cusip_is_cins", is_elementwise=True)
 
     def is_cins_base(self) -> pl.Expr:
-        """
-        Returns true if this CUSIP identifier is actually a CUSIP International
-        Numbering System (CINS) identifier (with the further restriction that
-        it does not use ‘I’, ‘O’ or ‘Z’ as its country code), false otherwise.
-        See also is_cins() and is_cins_extended().
-
-        Null if unable to parse.
-        """
         return self._expr.register_plugin(
             lib=_lib, symbol="pl_cusip_is_cins_base", is_elementwise=True
         )
 
     def is_cins_extended(self) -> pl.Expr:
-        """
-        Returns true if this CUSIP identifier is actually a CUSIP International
-        Numbering System (CINS) identifier (with the further restriction that
-        it does not use ‘I’, ‘O’ or ‘Z’ as its country code), false otherwise.
-        See also is_cins() and is_cins_extended().
-
-        Null if unable to parse.
-        """
         return self._expr.register_plugin(
             lib=_lib, symbol="pl_cusip_is_cins_extended", is_elementwise=True
         )

--- a/python/polars_istr/iban.py
+++ b/python/polars_istr/iban.py
@@ -1,8 +1,108 @@
 from __future__ import annotations
 import polars as pl
 from polars.utils.udfs import _get_shared_lib_location
+from ._utils import pl_plugin, StrOrExpr
 
 _lib = _get_shared_lib_location(__file__)
+
+
+def iban_country_code(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns country code from the IBAN, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_country_code",
+        is_elementwise=True,
+    )
+
+
+def iban_check_digits(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns check digits from the IBAN, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_check_digits",
+        is_elementwise=True,
+    )
+
+
+def iban_bban(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns BBAN string from the IBAN, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_bban",
+        is_elementwise=True,
+    )
+
+
+def iban_bank_id(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns bank identifier from the BBAN portion of the IBAN string,
+    or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_bank_identifier",
+        is_elementwise=True,
+    )
+
+
+def iban_branch_id(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns branch identifier from the BBAN portion of the IBAN string,
+    or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_branch_identifier",
+        is_elementwise=True,
+    )
+
+
+def iban_is_valid(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a boolean indicating whether the string is a valid IBAN string.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_is_valid",
+        is_elementwise=True,
+    )
+
+
+def iban_check(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a string that explains whether the IBAN string is valid or not.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_check",
+        is_elementwise=True,
+    )
+
+
+def iban_extract_all(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns all information from IBAN and return as a struct. Running this can be
+    faster than running the corresponding single queries together.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_iban_extract_all",
+        is_elementwise=True,
+    )
 
 
 @pl.api.register_expr_namespace("iban")
@@ -19,9 +119,6 @@ class IbanExt:
         self._expr: pl.Expr = expr
 
     def country_code(self) -> pl.Expr:
-        """
-        Returns country code from the IBAN, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_country_code",
@@ -29,9 +126,6 @@ class IbanExt:
         )
 
     def check_digits(self) -> pl.Expr:
-        """
-        Returns check digits from the IBAN, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_check_digits",
@@ -39,9 +133,6 @@ class IbanExt:
         )
 
     def bban(self) -> pl.Expr:
-        """
-        Returns BBAN string from the IBAN, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_bban",
@@ -49,10 +140,6 @@ class IbanExt:
         )
 
     def bank_id(self) -> pl.Expr:
-        """
-        Returns bank identifier from the BBAN portion of the IBAN string,
-        or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_bank_identifier",
@@ -60,10 +147,6 @@ class IbanExt:
         )
 
     def branch_id(self) -> pl.Expr:
-        """
-        Returns branch identifier from the BBAN portion of the IBAN string,
-        or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_branch_identifier",
@@ -71,9 +154,6 @@ class IbanExt:
         )
 
     def is_valid(self) -> pl.Expr:
-        """
-        Returns a boolean indicating whether the string is a valid IBAN string.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_is_valid",
@@ -81,9 +161,6 @@ class IbanExt:
         )
 
     def check(self) -> pl.Expr:
-        """
-        Returns a string that explains whether the IBAN string is valid or not.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_check",
@@ -91,10 +168,6 @@ class IbanExt:
         )
 
     def extract_all(self) -> pl.Expr:
-        """
-        Returns all information from IBAN and return as a struct. Running this can be
-        faster than running the corresponding single queries together.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_iban_extract_all",

--- a/python/polars_istr/isin.py
+++ b/python/polars_istr/isin.py
@@ -1,8 +1,71 @@
 from __future__ import annotations
 import polars as pl
 from polars.utils.udfs import _get_shared_lib_location
+from ._utils import pl_plugin, StrOrExpr
 
 _lib = _get_shared_lib_location(__file__)
+
+
+def isin_country_code(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns country code from the ISIN, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_isin_country_code",
+        is_elementwise=True,
+    )
+
+
+def isin_check_digit(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns check digits from the ISIN, or null if it cannot be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_isin_check_digit",
+        is_elementwise=True,
+    )
+
+
+def isin_security_id(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the 9-digit security identifier of the ISIN, or null if it cannot
+    be parsed.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_isin_security_id",
+        is_elementwise=True,
+    )
+
+
+def isin_is_valid(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a boolean indicating whether the string is a valid ISIN string.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_isin_is_valid",
+        is_elementwise=True,
+    )
+
+
+def isin_extract_all(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns all information from ISIN and return as a struct. Empty string means the part cannot
+    be extracted. Running this can be faster than running the corresponding single queries together.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_isin_full",
+        is_elementwise=True,
+    )
 
 
 @pl.api.register_expr_namespace("isin")
@@ -19,9 +82,6 @@ class IsinExt:
         self._expr: pl.Expr = expr
 
     def country_code(self) -> pl.Expr:
-        """
-        Returns country code from the ISIN, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_isin_country_code",
@@ -29,9 +89,6 @@ class IsinExt:
         )
 
     def check_digit(self) -> pl.Expr:
-        """
-        Returns check digits from the ISIN, or null if it cannot be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_isin_check_digit",
@@ -39,10 +96,6 @@ class IsinExt:
         )
 
     def security_id(self) -> pl.Expr:
-        """
-        Returns the 9-digit security identifier of the ISIN, or null if it cannot
-        be parsed.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_isin_security_id",
@@ -50,9 +103,6 @@ class IsinExt:
         )
 
     def is_valid(self) -> pl.Expr:
-        """
-        Returns a boolean indicating whether the string is a valid ISIN string.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_isin_is_valid",
@@ -60,10 +110,6 @@ class IsinExt:
         )
 
     def extract_all(self) -> pl.Expr:
-        """
-        Returns all information from ISIN and return as a struct. Empty string means the part cannot
-        be extracted. Running this can be faster than running the corresponding single queries together.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_isin_full",

--- a/python/polars_istr/type_alias.py
+++ b/python/polars_istr/type_alias.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+from typing import Union
 import sys
+import polars as pl
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias  # noqa
 else:  # 3.9, 3.8
     from typing_extensions import TypeAlias  # noqa
+
+StrOrExpr: TypeAlias = Union[str, pl.Expr]

--- a/python/polars_istr/url.py
+++ b/python/polars_istr/url.py
@@ -1,8 +1,105 @@
 from __future__ import annotations
 import polars as pl
 from polars.utils.udfs import _get_shared_lib_location
+from ._utils import pl_plugin, StrOrExpr
 
 _lib = _get_shared_lib_location(__file__)
+
+
+def url_is_special(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a boolean indicating whether the URL has a special scheme or not.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_is_special",
+        is_elementwise=True,
+    )
+
+
+def url_host(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the host of the URL, if possible.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_host",
+        is_elementwise=True,
+    )
+
+
+def url_path(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the path part of the URL, if possible.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_path",
+        is_elementwise=True,
+    )
+
+
+def url_domain(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the domain of the URL, if possible.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_domain",
+        is_elementwise=True,
+    )
+
+
+def url_fragment(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the fragment of the URL, if possible.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_fragment",
+        is_elementwise=True,
+    )
+
+
+def url_query(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns the query part of the URL, if possible.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_query",
+        is_elementwise=True,
+    )
+
+
+def url_is_valid(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a boolean indicating whether the string is a valid URL string.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_is_valid",
+        is_elementwise=True,
+    )
+
+
+def url_check(x: StrOrExpr) -> pl.Expr:
+    """
+    Returns a string that explains whether the URL string is valid or not.
+    """
+    return pl_plugin(
+        args=[x],
+        lib=_lib,
+        symbol="pl_url_check",
+        is_elementwise=True,
+    )
 
 
 @pl.api.register_expr_namespace("url")
@@ -19,9 +116,6 @@ class UrlExt:
         self._expr: pl.Expr = expr
 
     def is_special(self) -> pl.Expr:
-        """
-        Returns a boolean indicating whether the URL has a special scheme or not.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_is_special",
@@ -29,9 +123,6 @@ class UrlExt:
         )
 
     def host(self) -> pl.Expr:
-        """
-        Returns the host of the URL, if possible.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_host",
@@ -39,9 +130,6 @@ class UrlExt:
         )
 
     def path(self) -> pl.Expr:
-        """
-        Returns the path part of the URL, if possible.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_path",
@@ -49,9 +137,6 @@ class UrlExt:
         )
 
     def domain(self) -> pl.Expr:
-        """
-        Returns the domain of the URL, if possible.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_domain",
@@ -59,9 +144,6 @@ class UrlExt:
         )
 
     def fragment(self) -> pl.Expr:
-        """
-        Returns the fragment of the URL, if possible.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_fragment",
@@ -69,9 +151,6 @@ class UrlExt:
         )
 
     def query(self) -> pl.Expr:
-        """
-        Returns the query part of the URL, if possible.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_query",
@@ -79,9 +158,6 @@ class UrlExt:
         )
 
     def is_valid(self) -> pl.Expr:
-        """
-        Returns a boolean indicating whether the string is a valid URL string.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_is_valid",
@@ -89,9 +165,6 @@ class UrlExt:
         )
 
     def check(self) -> pl.Expr:
-        """
-        Returns a string that explains whether the URL string is valid or not.
-        """
         return self._expr.register_plugin(
             lib=_lib,
             symbol="pl_url_check",

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,15 +1,8 @@
 import polars as pl
-
-
 from polars.testing import assert_frame_equal
-
 from typing import List
-
 import pytest
-
-
 import polars_istr  # noqa: F401
-
 from typing import Optional
 
 


### PR DESCRIPTION
Now the crate has more up-to-date polars syntax, e.g. 

```python
import polars_istr as istr

df.select(
    istr.iban_country_code("iban_column")
)
```
which linters can understand. I also think we are ready for v0.1.0 release. 