### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,8 @@ jobs:
           merge-multiple: true
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: sdist-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
@ctdunc  I merged too quickly. Now both sdist-* and wheel-* files should be matched by pattern and should be downloaded correctly for maturin to upload.